### PR TITLE
사용자 OAuth 인증 코드 리팩토링

### DIFF
--- a/src/main/kotlin/com/millo/ilhayoung/auth/oauth2/CustomOAuth2User.kt
+++ b/src/main/kotlin/com/millo/ilhayoung/auth/oauth2/CustomOAuth2User.kt
@@ -14,43 +14,17 @@ class CustomOAuth2User(
     private val attributes: Map<String, Any>
 ) : OAuth2User {
 
-    override fun getAuthorities(): Collection<GrantedAuthority> {
-        // OAuth는 순수한 인증 정보만 담으므로 기본 권한만 부여
-        return listOf(SimpleGrantedAuthority("ROLE_USER"))
-    }
+    override fun getAuthorities(): Collection<GrantedAuthority> =
+        listOf(SimpleGrantedAuthority("ROLE_USER"))
 
     override fun getAttributes(): Map<String, Any> = attributes
 
     override fun getName(): String = user.email
 
-    /**
-     * OAuth 엔티티 반환
-     */
-    fun getUser(): OAuth = user
-
-    /**
-     * 사용자 ID 반환
-     */
-    fun getUserId(): String = user.id!!
-
-    /**
-     * 이메일 반환
-     */
+    // Convenience properties
     val email: String = user.email
-
-    /**
-     * OAuth 제공자 반환
-     */
     val provider: String = user.provider
-
-    /**
-     * OAuth 제공자 ID 반환
-     */
     val providerId: String = user.providerId
-
-    /**
-     * OAuth 이름 반환
-     */
     val displayName: String = user.getDisplayName()
 
     companion object {

--- a/src/main/kotlin/com/millo/ilhayoung/auth/oauth2/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/millo/ilhayoung/auth/oauth2/CustomOAuth2UserService.kt
@@ -46,31 +46,22 @@ class CustomOAuth2UserService : DefaultOAuth2UserService() {
         val existingUser = oauthRepository.findByEmail(oAuthUserInfo.getEmail())
         
         return if (existingUser.isPresent) {
-            // 기존 사용자 반환 (OAuth 이름 업데이트 로직 추가)
             val user = existingUser.get()
-            
-            // OAuth 이름이 없거나 변경된 경우 업데이트
             val oauthName = oAuthUserInfo.getName()
             if (user.oauthName != oauthName) {
                 user.oauthName = oauthName
                 oauthRepository.save(user)
-                user
-            } else {
-                // 기존 사용자 그대로 반환
-                user
             }
+            user
         } else {
-            // OAuth 이름 가져오기
-            val oauthName = oAuthUserInfo.getName()
-            
-            // 새로운 사용자 생성
             val newUser = OAuth.createFromOAuth(
                 email = oAuthUserInfo.getEmail(),
                 provider = provider,
                 providerId = oAuthUserInfo.getId(),
-                oauthName = oauthName
+                oauthName = oAuthUserInfo.getName()
             )
             oauthRepository.save(newUser)
+            newUser
         }
     }
 } 


### PR DESCRIPTION
- CustomOAuth2User 클래스에서 불필요한 함수 제거 및 간결한 코드로 변경
- OAuth2AuthenticationSuccessHandler에서 OIDC 사용자 처리 로직 추가
- CustomOAuth2UserService에서 사용자 이름 업데이트 로직 간소화 및 코드 정리